### PR TITLE
change deprecated "body" by "do"

### DIFF
--- a/source/deimos/ncurses/curses.d
+++ b/source/deimos/ncurses/curses.d
@@ -1483,7 +1483,7 @@ out (result)
 {
   assert (result < KEY_DL, "Invalid value for KEY_F(n)");
 }
-body
+do
 {
   return KEY_F0 + n;
 }


### PR DESCRIPTION
 Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.